### PR TITLE
Add --with-scheme48 option to ./configure, to indicate scheme48 location

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -32,8 +32,8 @@ SHARE = $(datadir)/scsh-$(VERSION)
 lib_dirs_list = ("${prefix}/lib/scsh/modules" "${prefix}/lib/scsh/modules/${VERSION}")
 
 SCHEME48VERSION =  1.9
-SCHEME48VM = @libdir@/scheme48-${SCHEME48VERSION}/scheme48vm
-SCHEME48 = @bindir@/scheme48
+SCHEME48VM = @S48DIR@/lib/scheme48-${SCHEME48VERSION}/scheme48vm
+SCHEME48 = @SCHEME48@
 
 COMPILED_LIBS = c/syscalls.so \
 	c/tty.so \
@@ -54,7 +54,7 @@ test: enough
 	$(srcdir)/build/test.sh $(srcdir)
 
 c/%.so: c/%.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LIBS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $< $(LIBS)
 
 SCHEME = scheme/command-line.scm \
 	 scheme/condition-handler.scm \

--- a/configure.ac
+++ b/configure.ac
@@ -9,10 +9,34 @@ AC_CANONICAL_HOST
 AC_PROG_CC
 AC_PROG_INSTALL
 
+dnl  Is there a non-default location for Scheme48?
+S48DIR=/usr
+AC_SUBST(S48DIR)
+AC_ARG_WITH([scheme48],
+            [Location of scheme48 installation (parent of bin/scheme48)],
+            [S48DIR=$withval])
+
+dnl  Check the location of the scheme48 directory; the following will
+dnl  also work if S48DIR has the default value of /usr
+AC_PATH_PROG([SCHEME48], [scheme48], [], [$S48DIR/bin:$PATH])
+if test -z "$SCHEME48"; then
+   AC_MSG_ERROR([Can't find scheme48 -- aborting (consider using --with-scheme48)])
+else
+   S48DIR=`dirname $SCHEME48`
+   S48DIR=`dirname $S48DIR`
+fi
+echo "SCHEME48=$SCHEME48,  S48DIR=$S48DIR"
+
+CPPFLAGS="$CPPFLAGS -I$S48DIR/include"
+
 # Checks for libraries.
 
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h limits.h netdb.h sgtty.h stdlib.h string.h sys/ioctl.h sys/param.h sys/time.h termios.h unistd.h utime.h])
+
+dnl  We need the scheme48.h headers, so bomb out if we can't find them.
+AC_CHECK_HEADERS([scheme48.h], [],
+                 [AC_MSG_ERROR([Can't find required scheme48.h (consider using --with-scheme48)])])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_PID_T


### PR DESCRIPTION
This also checks that we can find scheme48.h, and bombs out if not.
