### PR TITLE
Ensure scsh builds with bsdmake (as opposed to requiring non-default GNU...

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -54,7 +54,8 @@ enough: scsh scsh.image go
 test: enough
 	$(srcdir)/build/test.sh $(srcdir)
 
-c/%.so: c/%.c
+.SUFFIXES: .c .so
+.c.so:
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $< $(LIBS)
 
 SCHEME = scheme/command-line.scm \


### PR DESCRIPTION
... make)

Tested on FreeBSD 9.1, but should be portable to other bsdmake versions.
