### PR TITLE
Fixed install-scsh target to work with bsdmake

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -162,7 +162,7 @@ install: enough dirs install-scsh-image install-scsh
 
 install-scsh: scsh
         #install runner
-	$(RM) $(DESTDIR)$(bindir)/$(RUNNABLE)
+	rm $(DESTDIR)$(bindir)/$(RUNNABLE)
 	$(INSTALL_PROGRAM) scsh $(DESTDIR)$(bindir)/$(RUNNABLE)
 
 	for file in $(patsubst c/%,%,$(COMPILED_LIBS)) ; do \


### PR DESCRIPTION
A little premature for installation on FreeBSD, given issue9, but this appears to be the last impediment to using bsdmake instead of gmake.
