### PR TITLE
Unbreak github submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "rx"]
 	path = rx
-	url = git://github.com/scheme/rx.git
+	url = git@github.com:scheme/rx.git


### PR DESCRIPTION
github no longer supports unauthenticated checkout; change submodule URL to autenticated