### PR TITLE
Use https for github submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "rx"]
 	path = rx
-	url = git://github.com/scheme/rx.git
+	url = https://github.com/scheme/rx.git


### PR DESCRIPTION
Github discontinued unauthenticated access via the git@ protocol.