### PR TITLE
Allow use of search-paths for SCSH_LIB_DIRS.

### DIFF
--- a/scheme/lib-dirs.scm
+++ b/scheme/lib-dirs.scm
@@ -75,6 +75,7 @@
               (let ((val (read)))
                 (cond ((eof-object? val) '())
                       ((string? val) (cons val (recur)))
+                      ((symbol? val) (cons (symbol->string val) (recur)))
                       ((not val) (append default-lib-dirs (recur)))
                       (else 
                        (error 


### PR DESCRIPTION
This makes it easier to take an environment variable containing more than one directory in the SCSH_LIB_DIRS and parse it into the series of strings which SCSH_LIB_DIRS actually expects.