### PR TITLE
Don't not include util.h if libutil.h is available.

### DIFF
--- a/c/tty.c
+++ b/c/tty.c
@@ -35,7 +35,7 @@
 #endif
 
 #ifdef HAVE_UTIL_H
-#include <util.h>		/* openpty() on NetBSD */
+#include <util.h>		/* openpty() on NetBSD, macOS */
 #endif
 
 #ifndef countof

--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,7 @@ AC_CHECK_FUNC(openpty, have_openpty=yes, [
   AC_CHECK_LIB(util, openpty, have_openpty=yes need_libutil=yes)])
 if test "$have_openpty" = "yes"; then
   AC_DEFINE(HAVE_OPENPTY, 1, [Define to 1 if you have the 'openpty' function])
-  AC_CHECK_HEADERS(libutil.h util.h, break)
+  AC_CHECK_HEADERS(libutil.h util.h)
   if test "$need_libutil" = "yes"; then
     LIBS="${LIBS} -lutil"
   fi


### PR DESCRIPTION
macOS has openpty in util.h, but also has libutil.h.